### PR TITLE
Fixes MOBILE-463

### DIFF
--- a/lib/mm.js
+++ b/lib/mm.js
@@ -964,6 +964,31 @@ anchor      (\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(
     },
 
     /**
+     * Converts an objects values to strings where appropriate.
+     * Arrays (associative or otherwise) will be maintained.
+     *
+     * @param {Object} data The data that needs all the non-object values set
+     *                      to strings.
+     *
+     * @return {Object} The cleaned object, with multilevel array and objects
+     *                  preserved.
+     */
+    _convertValuesToString: function(data) {
+        var result = [];
+        if (!_.isArray(data) && _.isObject(data)) {
+            result = {};
+        }
+        for (var el in data) {
+            if (_.isObject(data[el])) {
+                result[el] = MM._convertValuesToString(data[el])
+            } else {
+                result[el] = data[el] + '';
+            }
+        }
+        return result;
+    },
+
+    /**
      * A wrapper function for a moodle WebService call.
      *
      * @param {string} method The WebService method to be called.
@@ -976,10 +1001,7 @@ anchor      (\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(
      */
     moodleWSCall: function(method, data, callBack, preSets, errorCallBack) {
 
-        // Force data elements to be string.
-        for (var el in data) {
-            data[el] = data[el] + '';
-        }
+        var data = MM._convertValuesToString(data);
         preSets = MM._verifyPresets(preSets);
 
         data.wsfunction = method;


### PR DESCRIPTION
Multilevel objects used as data for moodleWSCall were being converted to:
"[Object object]" rather than their internal values being converted.
This fix maintains current functionality and additionally allows multilevel
data to be sent to a web service.
