### PR TITLE
MOBILE-474 Use requirejs instead require for including files using Requi...

### DIFF
--- a/externallib/text.js
+++ b/externallib/text.js
@@ -239,7 +239,7 @@ define(['module'], function (module) {
             process.versions &&
             !!process.versions.node)) {
         //Using special require.nodeRequire, something added by r.js.
-        fs = require.nodeRequire('fs');
+        fs = require('fs');
 
         text.get = function (url, callback, errback) {
             try {

--- a/index.html
+++ b/index.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="css/layout.css">
     <link rel="stylesheet" href="css/styles.css">
-    <script type="text/javascript">
-        // Support for Node Webkit.
-        window.requireNode = window.require;
-        window.require = undefined;
-    </script>
 	<script src="cordova.js"></script>
     <script src="childbrowser.js"></script>
     <script src="webintent.js"></script>

--- a/lib/app.js
+++ b/lib/app.js
@@ -21,20 +21,18 @@
  * @version 1.2
  */
 
-// Support for Node Webkit.
-require.nodeRequire = window.requireNode;
 
 // Base path for all the files required.
-require.config({
+requirejs.config({
     paths: {
         root: '..'
     }
 });
 
-// Requirements for launching the app, the function is not executed until both 
+// Requirements for launching the app, the function is not executed until both
 // files are fully loaded.
 // We need at least the config.json file with all the settings and the language file.
-require(['root/externallib/text!root/config.json', 'root/externallib/text!root/lang/en.json'],
+requirejs(['root/externallib/text!root/config.json', 'root/externallib/text!root/lang/en.json'],
 function(config, lang) {
     config = JSON.parse(config);
 
@@ -43,7 +41,7 @@ function(config, lang) {
     MM.lang.base = JSON.parse(lang);
 
     // Once the config and base lang are loaded, we load all the plugins defined in the config.json file.
-    require.config({
+    requirejs.config({
         baseUrl: 'plugins',
         packages: config.plugins
     });
@@ -52,7 +50,7 @@ function(config, lang) {
     var extraLang = 'root/externallib/text!root/lang/' + config.default_lang + '.json';
     config.plugins.unshift(extraLang);
 
-    require(config.plugins,
+    requirejs(config.plugins,
         function(extraLang) {
             MM.lang.loadLang('core', config.default_lang, JSON.parse(extraLang));
             $(document).ready(function() {


### PR DESCRIPTION
...reJS

The initial version of RequireJS we used for loading plugins didn't allow us to use a function name different than require for including files
New versions can use req or requirejs plus to require
Using require creates conflicts with other frameworks like NodeJS
