### PR TITLE
MOBILE-487 Scrolling in Android 2.1 and 2.3 doesn't work correctly

### DIFF
--- a/lib/mm.js
+++ b/lib/mm.js
@@ -458,7 +458,8 @@ var MM = {
         $("#main-wrapper").css("overflow", "visible");
         $("#panel-left, #panel-center, #panel-right").addClass("no-overflow");
         $(".header-wrapper").addClass("header-fixed");
-        MM.util.avoidHorizontalScrolling();
+        // See https://tracker.moodle.org/browse/MOBILE-487
+        //MM.util.avoidHorizontalScrolling();
     },
 
     /**


### PR DESCRIPTION
We should try to fix the avoid HorizontalScrolling but it may not worth
because is for old devices
