### PR TITLE
Now using MM.config.app_id as base folder in Android

### DIFF
--- a/lib/mm.fs.js
+++ b/lib/mm.fs.js
@@ -41,6 +41,14 @@ MM.fs = {
             return;
         }
 
+        if( MM.getOS() == 'android' && typeof(MM.config.app_id) == "undefined" ){
+            MM.errorLog("MM.config not defined yet", "FS");
+            setTimeout(function() {
+                MM.fs.init(callBack);
+            }, 2000);
+            return;
+        }
+
         if (!callBack) {
             callBack = function() {};
         }
@@ -53,7 +61,7 @@ MM.fs = {
         }
 
         if (MM.getOS() == 'android') {
-            MM.fs.basePath = 'Android/data/com.moodle.moodlemobile';
+            MM.fs.basePath = 'Android/data/'+MM.config.app_id;
         }
         MM.fs.loadFS(callBack);
     },
@@ -65,10 +73,10 @@ MM.fs = {
     getRoot: function() {
         if (!MM.fs.fileSystemRoot) {
             MM.fs.loadFS(function() {
-                MM.fs.fileSystemRoot.toNativeURL()
+                MM.fs.fileSystemRoot.toURL()
             });
         } else {
-            var path = MM.fs.fileSystemRoot.toNativeURL();
+            var path = MM.fs.fileSystemRoot.toURL();
             // Android 4.2 and onwards
             //path = path.replace("storage/emulated/0", "sdcard");
             return path;
@@ -102,7 +110,7 @@ MM.fs = {
     },
 
     fileExists: function(path, successCallback, errorCallback) {
-        var directory = path.substring(0, path.lastIndexOf('/') - 1);
+        var directory = path.substring(0, path.lastIndexOf('/') );
         var filename = path.substr(path.lastIndexOf('/') + 1);
         MM.fs.fileSystemRoot.getDirectory(
             directory,
@@ -111,7 +119,7 @@ MM.fs = {
                 entry.getFile(
                     filename, { create: false },
                     function(entryFile) {
-                        successCallback(entryFile.toNativeURL());
+                        successCallback(entryFile.toURL());
                     },
                     errorCallback
                 );
@@ -131,7 +139,7 @@ MM.fs = {
             baseRoot = dirEntry;
         }
 
-        MM.log('FS: Creating directory ' + paths[0] + 'in' + baseRoot.toNativeURL());
+        MM.log('FS: Creating directory ' + paths[0] + 'in' + baseRoot.toURL());
         baseRoot.getDirectory(
             paths[0],
             {create: true, exclusive: false},


### PR DESCRIPTION
Now using MM.config.app_id as base folder in Android instead of hardcoding com.moodle.mobile.
Fixed a minor bug in fileExists.
Now using toURL instead of toNativeURL (deprecated).
