### PR TITLE
Mobile-900: Unable to upload audios in Node-Webkit

### DIFF
--- a/lib/mm.emulator.js
+++ b/lib/mm.emulator.js
@@ -393,10 +393,6 @@ MM.cordova = {
             this.fullPath = fullPath;
         };
 
-        var FileReader = function(fullPath) {
-            this.fullPath = fullPath;
-        };
-
         FileWriter.prototype.write = function(data) {
             var fs = require('fs');
 
@@ -411,22 +407,6 @@ MM.cordova = {
                 }
             });
 
-        };
-
-        FileReader.prototype.readAsText = function(file) {
-            var fs = require('fs');
-
-            var self = this;
-
-            fs.readFile(file.localURL, function(err, data) {
-                if(err) {
-                    if(self.onerror)
-                        self.onerror();
-                } else {
-                    if(self.onloadend)
-                        self.onloadend({target: {result: data}});
-                }
-            });
         };
 
         DirectoryReader.prototype.readEntries = function(successCallback, errorCallback) {

--- a/lib/mm.fs.js
+++ b/lib/mm.fs.js
@@ -404,7 +404,8 @@ MM.fs = {
                     },
                     function() {
                         errorCallBack(2);
-                    }
+                    },
+                    MM.inNodeWK
                 );
             },
             function() {


### PR DESCRIPTION
A custom implementation of FileReader was added in a previous PullRequest. That version didn't have readAsBinaryString implemented, and that caused the error.

With this PullRequest, the app uses the default implementation of FileReader again. A minor fix has been applied to MM.fs.findFileAndReadContents to make it work with this implementation.