### PR TITLE
MOBILE-908: Delete tmp files after being uploaded

### DIFF
--- a/lib/mm.emulator.js
+++ b/lib/mm.emulator.js
@@ -763,6 +763,25 @@ MM.cordova = {
             });
         };
 
+        window.resolveLocalFileSystemURL = function(path, successCallback, errorCallback) {
+            var fs = require('fs');
+
+            if (fs.existsSync(path)) {
+
+                var filename = getFileName(path);
+
+                if(fs.statSync(path).isFile()) {
+                    var entry = new FileEntry(filename, path);
+                    successCallback(entry);
+                } else {
+                    var entry = new DirectoryEntry(filename, path);
+                    successCallback(entry);
+                }
+            } else if(errorCallback) {
+                errorCallback();
+            }
+        };
+
         // FileTransfer API.
         window.FileTransfer = function() {};
 
@@ -773,7 +792,7 @@ MM.cordova = {
                 buffer[i] = view[i];
             }
             return buffer;
-        }
+        };
 
         // Download files using Node.js http client.
         window.FileTransfer.prototype.download = function(url, filePath, successCallback, errorCallback, options, debug) {
@@ -978,7 +997,8 @@ MM.cordova = {
                                         var audiofiles = [];
                                         audiofiles.push({
                                             name: filename,
-                                            fullPath: tmpPath
+                                            fullPath: tmpPath,
+                                            localURL: tmpPath
                                         });
                                         MM.widgets.dialogClose();
                                         captureSuccess(audiofiles);

--- a/lib/mm.fs.js
+++ b/lib/mm.fs.js
@@ -515,5 +515,30 @@ MM.fs = {
         else{
             baseRoot.getFile(filename, {create: true}, successCallBack, errorCallBack);
         }
-    }
+    },
+
+    /**
+     * Gets a file that might be outside the app's folder.
+     *
+     * @param  {String} fileURI         Path to the file to get.
+     * @param  {[type]} successCallBack Function to be called when the file is retrieved.
+     * @param  {[type]} errorCallBack   Function to be called when an error occurs.
+     */
+    getExternalFile: function(fileURI, successCallBack, errorCallBack) {
+        window.resolveLocalFileSystemURL(fileURI, successCallBack, errorCallBack);
+    },
+
+    /**
+     * Remove a file that might be outside the app's folder.
+     * @param  {string} path            The absolute path of the file
+     * @param  {object} successCallback Success callback function
+     * @param  {object} errorCallback   Error callback function
+     */
+    removeExternalFile: function(path, successCallback, errorCallback) {
+        MM.log('FS: Removing file ' + path, 'FS');
+
+        MM.fs.getExternalFile(path, function(fileEntry){
+            fileEntry.remove(successCallback, errorCallback);
+        }, errorCallback);
+    },
 };


### PR DESCRIPTION
Temporary files are now deleted after being uploaded.

* iOS: Always delete the files, since they are always copied to tmp folder.
* Android: Delete Video, Audio and Image captured. Browsed images are NOT deleted.
* Desktop: Delete Audio and Image captured. Browsed images are NOT deleted.